### PR TITLE
Add license to gemspec

### DIFF
--- a/rb-fchange.gemspec
+++ b/rb-fchange.gemspec
@@ -5,6 +5,7 @@ require "rb-fchange/version"
 Gem::Specification.new do |s|
   s.name        = %q{rb-fchange}
   s.version     = FChange::VERSION
+  s.license     = "MIT"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["stereobooster"]
   s.date = %q{2011-05-15}


### PR DESCRIPTION
so that tools like LicenseFinder can check licenses across gems better.

See https://github.com/rubygems/rubygems.org/issues/363 too
