### PR TITLE
Add license to gemspec

### DIFF
--- a/rb-fchange.gemspec
+++ b/rb-fchange.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
     "rb-fchange.gemspec"
   ]
   s.homepage = %q{http://github.com/stereobooster/rb-fchange}
+  s.license = "MIT"
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}
   s.summary = %q{A Ruby wrapper for Windows Kernel functions for monitoring the specified directory or subtree}


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.
